### PR TITLE
Fix initialDelaySeconds

### DIFF
--- a/charts/vaultwarden/templates/statefulset.yaml
+++ b/charts/vaultwarden/templates/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             httpGet:
               path: /alive
               port: 8080
-              initialDelaySeconds: 5
+            initialDelaySeconds: 5
           {{- if .Values.data }}
           volumeMounts:
             - name: {{ .Values.data.name }}


### PR DESCRIPTION
initialDelaySeconds is readiness value not a httpget value https://kubernetes.io/fr/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/